### PR TITLE
python library is now called python3

### DIFF
--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.6.3-alpine3.10
 ENV LIBV8_VERSION 7.3.492.27.1
 RUN apk add --update --no-cache libstdc++ && \
-    apk add --update --no-cache --virtual build-deps build-base make python git bash && \
+    apk add --update --no-cache --virtual build-deps build-base make python3 git bash && \
     gem install libv8 -v ${LIBV8_VERSION} && \
     gem install therubyracer && \
     apk del build-deps


### PR DESCRIPTION
When trying to stand this container up, you get an error:

```bash
#9 1.435 ERROR: unable to select packages:
#9 1.465   python (no such package):
#9 1.465     required by: build-deps-20210507.160404[python]
```